### PR TITLE
Fix for docker file throwing NVIDIA GPG key error

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,10 @@ ENV TORCH_CUDA_ARCH_LIST="6.0 6.1 7.0+PTX"
 ENV TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 ENV CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
 
+# To avoid Nvidia GPG error
+RUN rm /etc/apt/sources.list.d/cuda.list
+RUN rm /etc/apt/sources.list.d/nvidia-ml.list
+
 RUN apt-get update && apt-get install -y git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 libgl1-mesa-glx\
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fixes the error caused by NVIDIA CUDA repo key rotation. Solution is based on this issue thread on [nvidia container repo](https://github.com/NVIDIA/nvidia-docker/issues/1631).

# Before
```bash
Step 7/18 : ENV CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
 ---> Running in dc30f48c6c8d
Removing intermediate container dc30f48c6c8d
 ---> 36bf6d1ba6b0
Step 8/18 : RUN apt-get update && apt-get install -y git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 libgl1-mesa-glx    && apt-get clean     && rm -rf /var/lib/apt/lists/*
 ---> Running in 57c58890b8f9
Get:1 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease [1581 B]
Err:1 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
Get:2 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]
Get:3 http://archive.ubuntu.com/ubuntu bionic InRelease [242 kB]
Get:4 http://security.ubuntu.com/ubuntu bionic-security/multiverse amd64 Packages [22.8 kB]
Get:5 http://security.ubuntu.com/ubuntu bionic-security/main amd64 Packages [2937 kB]
Get:6 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]
Ign:7 https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64  InRelease
Get:8 https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64  Release [564 B]
Get:9 https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64  Release.gpg [833 B]
Get:10 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]
Get:11 http://archive.ubuntu.com/ubuntu bionic/main amd64 Packages [1344 kB]
Get:12 https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64  Packages [73.8 kB]
Get:13 http://archive.ubuntu.com/ubuntu bionic/universe amd64 Packages [11.3 MB]
Get:14 http://security.ubuntu.com/ubuntu bionic-security/restricted amd64 Packages [1100 kB]
Get:15 http://security.ubuntu.com/ubuntu bionic-security/universe amd64 Packages [1533 kB]
Get:16 http://archive.ubuntu.com/ubuntu bionic/restricted amd64 Packages [13.5 kB]
Get:17 http://archive.ubuntu.com/ubuntu bionic/multiverse amd64 Packages [186 kB]
Get:18 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [2310 kB]
Get:19 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [3369 kB]
Get:20 http://archive.ubuntu.com/ubuntu bionic-updates/restricted amd64 Packages [1141 kB]
Get:21 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse amd64 Packages [29.9 kB]
Get:22 http://archive.ubuntu.com/ubuntu bionic-backports/main amd64 Packages [12.2 kB]
Get:23 http://archive.ubuntu.com/ubuntu bionic-backports/universe amd64 Packages [12.9 kB]
Reading package lists...
W: GPG error: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
E: The repository 'https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease' is not signed.
The command '/bin/sh -c apt-get update && apt-get install -y git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 libgl1-mesa-glx    && apt-get clean     && rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100
```
# After 
```bash
Step 8/20 : RUN rm /etc/apt/sources.list.d/cuda.list
 ---> Running in dbba7c20cb69
Removing intermediate container dbba7c20cb69
 ---> f0c6f6210fb3
Step 9/20 : RUN rm /etc/apt/sources.list.d/nvidia-ml.list
 ---> Running in 4f890df7d919
Removing intermediate container 4f890df7d919
 ---> d51d8e7ad272
Step 10/20 : RUN apt-get update && apt-get install -y git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 libgl1-mesa-glx    && apt-get clean     && rm -rf /var/lib/apt/lists/*
 ---> Running in 94b2800b6f08
Get:1 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]
Get:2 http://archive.ubuntu.com/ubuntu bionic InRelease [242 kB]
Get:3 http://security.ubuntu.com/ubuntu bionic-security/main amd64 Packages [2937 kB]
Get:4 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]
Get:5 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]
Get:6 http://archive.ubuntu.com/ubuntu bionic/main amd64 Packages [1344 kB]
Get:7 http://archive.ubuntu.com/ubuntu bionic/multiverse amd64 Packages [186 kB]
Get:8 http://archive.ubuntu.com/ubuntu bionic/universe amd64 Packages [11.3 MB]
Get:9 http://security.ubuntu.com/ubuntu bionic-security/multiverse amd64 Packages [22.8 kB]
Get:10 http://security.ubuntu.com/ubuntu bionic-security/restricted amd64 Packages [1100 kB]
Get:11 http://security.ubuntu.com/ubuntu bionic-security/universe amd64 Packages [1533 kB]
Get:12 http://archive.ubuntu.com/ubuntu bionic/restricted amd64 Packages [13.5 kB]
Get:13 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [3369 kB]
Get:14 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse amd64 Packages [29.9 kB]
Get:15 http://archive.ubuntu.com/ubuntu bionic-updates/restricted amd64 Packages [1141 kB]
Get:16 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [2310 kB]
Get:17 http://archive.ubuntu.com/ubuntu bionic-backports/main amd64 Packages [12.2 kB]
Get:18 http://archive.ubuntu.com/ubuntu bionic-backports/universe amd64 Packages [12.9 kB]
Fetched 25.8 MB in 3s (8474 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  git-man krb5-locales less libbsd0 libcurl3-gnutls libdrm-amdgpu1
  libdrm-common libdrm-intel1 libdrm-nouveau2 libdrm-radeon1 libdrm2 libedit2
  libelf1 liberror-perl libexpat1 libgl1 libgl1-mesa-dri libglapi-mesa
  libglib2.0-data libglvnd0 libglx-mesa0 libglx0 libgssapi-krb5-2 libice6
  libicu60 libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libllvm10
  libnghttp2-14 libpciaccess0 libpsl5 libpthread-stubs0-dev librtmp1
  libsensors4 libssl1.0.0 libx11-6 libx11-data libx11-dev libx11-doc
  libx11-xcb1 libxau-dev libxau6 libxcb-dri2-0 libxcb-dri3-0 libxcb-glx0
  libxcb-present0 libxcb-sync1 libxcb1 libxcb1-dev libxdamage1 libxdmcp-dev
  libxdmcp6 libxfixes3 libxml2 libxmuu1 libxrender1 libxshmfence1 libxxf86vm1
  openssh-client publicsuffix shared-mime-info x11-common x11proto-core-dev
  x11proto-dev xauth xdg-user-dirs xorg-sgml-doctools xtrans-dev
Suggested packages:
  gettext-base git-daemon-run | git-daemon-sysvinit git-doc git-el git-email
  git-gui gitk gitweb git-cvs git-mediawiki git-svn krb5-doc krb5-user
  pciutils lm-sensors libxcb-doc keychain libpam-ssh monkeysphere ssh-askpass
The following NEW packages will be installed:
  git git-man krb5-locales less libbsd0 libcurl3-gnutls libdrm-amdgpu1
  libdrm-common libdrm-intel1 libdrm-nouveau2 libdrm-radeon1 libdrm2 libedit2
  libelf1 liberror-perl libexpat1 libgl1 libgl1-mesa-dri libgl1-mesa-glx
  libglapi-mesa libglib2.0-0 libglib2.0-data libglvnd0 libglx-mesa0 libglx0
  libgssapi-krb5-2 libice6 libicu60 libk5crypto3 libkeyutils1 libkrb5-3
  libkrb5support0 libllvm10 libnghttp2-14 libpciaccess0 libpsl5
  libpthread-stubs0-dev librtmp1 libsensors4 libsm6 libssl1.0.0 libx11-6
  libx11-data libx11-dev libx11-doc libx11-xcb1 libxau-dev libxau6
  libxcb-dri2-0 libxcb-dri3-0 libxcb-glx0 libxcb-present0 libxcb-sync1 libxcb1
  libxcb1-dev libxdamage1 libxdmcp-dev libxdmcp6 libxext6 libxfixes3 libxml2
  libxmuu1 libxrender-dev libxrender1 libxshmfence1 libxxf86vm1 ninja-build
  openssh-client publicsuffix shared-mime-info x11-common x11proto-core-dev
  x11proto-dev xauth xdg-user-dirs xorg-sgml-doctools xtrans-dev
0 upgraded, 77 newly installed, 0 to remove and 103 not upgraded.
Need to get 47.7 MB of archives.
After this operation, 434 MB of additional disk space will be used.
```
